### PR TITLE
Fix env file generated problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Azure Pipelines templates shared by various subprojects such as `scipp` and `sci
 
 The pipelines uses a common conda environment file for its various stages passes as `conda_env`.
 For c++ projects where you will have build dependencies as well as run dependencies, this will mean that all stages, not just those conducting the build, will bring in build dependencies as well as run dependencies
-There is special mitigation for this in the documentation stages, where the input environment file is stripped of blocks identified as build dependencies, i.e those between lines `# Build` and the next empty line.
+There is special mitigation for this in the documentation and build stages, where the input environment file is stripped of blocks identified as irrelevant dependencies for the job at hand, i.e those between lines `# Build` and the next empty line when generating documentation from a package.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Pipelines
 
 Azure Pipelines templates shared by various subprojects such as `scipp` and `scippneutron`.
+
+## Caveats
+
+The pipelines uses a common conda environment file for its various stages passes as `conda_env`.
+For c++ projects where you will have build dependencies as well as run dependencies, this will mean that all stages, not just those conducting the build, will bring in build dependencies as well as run dependencies
+There is special mitigation for this in the documentation stages, where the input environment file is stripped of blocks identified as build dependencies, i.e those between lines `# Build` and the next empty line.
+

--- a/build.yml
+++ b/build.yml
@@ -70,7 +70,11 @@ jobs:
           conda install --yes conda-build
           conda config --set always_yes yes --set changeps1 no
           # Specify env name and python version in env file
-          sed 's/- python$/- python=${{ parameters.py_version }}/g' ${{ parameters.conda_env }} > tempenv.yml
+          sed 's/- python$/- python=${{ parameters.py_version }}/g' ${{ parameters.conda_env }} > tempenv0.yml
+          # Ignore run dependencies for building
+          sed -e '/# Run/,/^$/d' tempenv0.yml > tempenv1.yml
+          # Ignore docs dependencies for building
+          sed -e '/# Docs/,/^$/d' tempenv1.yml > tempenv.yml
           conda env create -f tempenv.yml -n tempenv
         displayName: 'Create conda environment'
 

--- a/build.yml
+++ b/build.yml
@@ -75,12 +75,14 @@ jobs:
           sed -e '/# Run/,/^$/d' tempenv0.yml > tempenv1.yml
           # Ignore docs dependencies for building
           sed -e '/# Docs/,/^$/d' tempenv1.yml > tempenv.yml
+          cat tempenv.yml
           conda env create -f tempenv.yml -n tempenv
         displayName: 'Create conda environment'
 
       - bash: |
           set -ex
           source activate tempenv
+          conda list
           python tools/build_cpp.py --prefix=$SCIPP_INSTALL_PREFIX
         displayName: 'Build and run C++ tests'
 

--- a/documentation.yml
+++ b/documentation.yml
@@ -46,7 +46,6 @@ stages:
               # Specify python version in env file
               sed 's/- python$/- python=${{ parameters.py_version }}/g' ${{ parameters.conda_env }} > tempenv0.yml
               # Strip build dependencies
-              cat tempenv0.yml
               sed -e '/# Build/,/^$/d' tempenv0.yml > tempenv.yml
               cat tempenv.yml
               conda env create -f tempenv.yml -n tempenv
@@ -54,10 +53,8 @@ stages:
           - bash: |
               set -ex
               source activate tempenv
-              conda list
-              conda install -c conda-forge conda-tree --yes
-              conda-tree whoneeds boost
               conda install "$(packages_dir)/$(package_name)/"*.tar.bz2
+              conda list
             displayName: 'Install previously built conda package'
           - bash: |
               set -ex

--- a/documentation.yml
+++ b/documentation.yml
@@ -46,7 +46,9 @@ stages:
               # Specify python version in env file
               sed 's/- python$/- python=${{ parameters.py_version }}/g' ${{ parameters.conda_env }} > tempenv0.yml
               # Strip build dependencies
+              cat tempenv0.yml
               sed -e '/# Build/,/^$/d' tempenv0.yml > tempenv.yml
+              cat tempenv.yml
               conda env create -f tempenv.yml -n tempenv
             displayName: 'Create Conda environment'
           - bash: |

--- a/documentation.yml
+++ b/documentation.yml
@@ -54,6 +54,7 @@ stages:
           - bash: |
               set -ex
               source activate tempenv
+              conda list
               conda install -c conda-forge conda-tree --yes
               conda-tree whoneeds boost
               conda install "$(packages_dir)/$(package_name)/"*.tar.bz2

--- a/documentation.yml
+++ b/documentation.yml
@@ -54,6 +54,8 @@ stages:
           - bash: |
               set -ex
               source activate tempenv
+              conda install conda-tree --yes
+              conda-tree whoneeds boost
               conda install "$(packages_dir)/$(package_name)/"*.tar.bz2
             displayName: 'Install previously built conda package'
           - bash: |

--- a/documentation.yml
+++ b/documentation.yml
@@ -54,7 +54,7 @@ stages:
           - bash: |
               set -ex
               source activate tempenv
-              conda install conda-tree --yes
+              conda install -c conda-forge conda-tree --yes
               conda-tree whoneeds boost
               conda install "$(packages_dir)/$(package_name)/"*.tar.bz2
             displayName: 'Install previously built conda package'

--- a/documentation.yml
+++ b/documentation.yml
@@ -45,6 +45,8 @@ stages:
               set -ex
               # Specify python version in env file
               sed 's/- python$/- python=${{ parameters.py_version }}/g' ${{ parameters.conda_env }} > tempenv.yml
+              # Strip build dependencies
+              sed '/# Build/,/^$/d' tempenv.yml > tempenv.yml
               conda env create -f tempenv.yml -n tempenv
             displayName: 'Create Conda environment'
           - bash: |

--- a/documentation.yml
+++ b/documentation.yml
@@ -44,9 +44,9 @@ stages:
           - bash: |
               set -ex
               # Specify python version in env file
-              sed 's/- python$/- python=${{ parameters.py_version }}/g' ${{ parameters.conda_env }} > tempenv.yml
+              sed 's/- python$/- python=${{ parameters.py_version }}/g' ${{ parameters.conda_env }} > tempenv0.yml
               # Strip build dependencies
-              sed -e '/# Build/,/^$/d' tempenv.yml > tempenv.yml
+              sed -e '/# Build/,/^$/d' tempenv0.yml > tempenv.yml
               conda env create -f tempenv.yml -n tempenv
             displayName: 'Create Conda environment'
           - bash: |

--- a/documentation.yml
+++ b/documentation.yml
@@ -46,7 +46,7 @@ stages:
               # Specify python version in env file
               sed 's/- python$/- python=${{ parameters.py_version }}/g' ${{ parameters.conda_env }} > tempenv.yml
               # Strip build dependencies
-              sed '/# Build/,/^$/d' tempenv.yml > tempenv.yml
+              sed -e '/# Build/,/^$/d' tempenv.yml > tempenv.yml
               conda env create -f tempenv.yml -n tempenv
             displayName: 'Create Conda environment'
           - bash: |


### PR DESCRIPTION
Problems resulting from having a single env file. Partial fix for scipp/scipp#1888

The following illustrates the problem (and close to actual situation). This is the example environment file.
```yaml
dependencies:
# Build
  - boost-cpp=1.76
# Run
  - mantid-framework # built with and has runtime dependency on 1.75
``` 
So attempt create an env from this file for c++ build, but you can't because while you only need `boost-cpp` for c++ build, it's also brining in all runtime dependencies, including mantid-framework which clashes version of `boost-cpp`. The same situation is also encountered for making the docs, where you only need `mantid-framework` (no c++ build dependencies), but the conflict is nevertheless encountered.

We could have used different env-files [see conda-merge](https://pypi.org/project/conda-merge/) but we have enough of these already, so on-the-fly redacting, which can be done without too much effort via `sed`, of these seems appropriate.
