### PR TITLE
Notebooks pipeline

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -17,6 +17,10 @@ parameters:
 - name: publish_docs
   type: boolean
   default: true
+- name: publish_package
+  type: boolean
+  default: true
+
 
 stages:
   - stage: 'deploy'
@@ -44,21 +48,22 @@ stages:
               conda install -c conda-forge --yes anaconda-client
               conda config --set always_yes yes --set changeps1 no
             displayName: 'Install anaconda-client'
-          - ${{ each package in parameters.package_list }}:
-            - task: DownloadBuildArtifacts@0
-              inputs:
-                buildType: 'current'
-                specificBuildWithTriggering: true
-                downloadType: 'single'
-                artifactName: ${{ package.Key }}
-                downloadPath: '$(Build.StagingDirectory)/packages'
-              displayName: 'Retrieve built conda package'
-            - bash: |
-                set -ex
-                anaconda --token "$ANACONDA_TOKEN" upload --user scipp --label ${{ parameters.conda_label }} '$(Build.StagingDirectory)/packages/${{ package.Key }}/'*.tar.bz2 --force
-              env:
-                ANACONDA_TOKEN: $(anaconda_token_secret)
-              displayName: 'Deploy to anaconda cloud ${{ package.Key }}'
+          - ${{ if eq(parameters.publish_package, true) }}:
+            - ${{ each package in parameters.package_list }}:
+              - task: DownloadBuildArtifacts@0
+                inputs:
+                  buildType: 'current'
+                  specificBuildWithTriggering: true
+                  downloadType: 'single'
+                  artifactName: ${{ package.Key }}
+                  downloadPath: '$(Build.StagingDirectory)/packages'
+                displayName: 'Retrieve built conda package'
+              - bash: |
+                  set -ex
+                  anaconda --token "$ANACONDA_TOKEN" upload --user scipp --label ${{ parameters.conda_label }} '$(Build.StagingDirectory)/packages/${{ package.Key }}/'*.tar.bz2 --force
+                env:
+                  ANACONDA_TOKEN: $(anaconda_token_secret)
+                displayName: 'Deploy to anaconda cloud ${{ package.Key }}'
           - ${{ if eq(parameters.publish_docs, true) }}:
             - task: DownloadBuildArtifacts@0
               inputs:

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -13,7 +13,7 @@ parser.add_argument('--builder', default='html')
 
 if __name__ == '__main__':
 
-    args = parser.parse_known_args()
+    args = parser.parse_known_args()[0]
 
     # Build the docs with sphinx-build
     status = subprocess.check_call([

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -10,6 +10,7 @@ parser = argparse.ArgumentParser(description='Build doc pages with sphinx')
 parser.add_argument('--prefix', default='build')
 parser.add_argument('--work_dir', default='.doctrees')
 parser.add_argument('--builder', default='html')
+parser.add_argument('--no-setup', action='store_true', default=False)
 
 if __name__ == '__main__':
 

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -10,11 +10,10 @@ parser = argparse.ArgumentParser(description='Build doc pages with sphinx')
 parser.add_argument('--prefix', default='build')
 parser.add_argument('--work_dir', default='.doctrees')
 parser.add_argument('--builder', default='html')
-parser.add_argument('--no-setup', action='store_true', default=False)
 
 if __name__ == '__main__':
 
-    args = parser.parse_args()
+    args = parser.parse_known_args()
 
     # Build the docs with sphinx-build
     status = subprocess.check_call([

--- a/documentation.yml
+++ b/documentation.yml
@@ -71,7 +71,7 @@ stages:
               set -ex
               cd docs
               source activate tempenv
-              python build_docs.py --builder=doctest --prefix=$(docs_build_dir) --work_dir=$(mktemp -d)
+              python build_docs.py --builder=doctest --prefix=$(docs_build_dir) --work_dir=$(mktemp -d) --no-setup
             displayName: 'Run doctest'
           - task: PublishBuildArtifacts@1
             inputs:

--- a/documentation.yml
+++ b/documentation.yml
@@ -10,6 +10,10 @@ parameters:
 - name: py_version
   type: string
   default: ''
+- name: build_package
+  type: boolean
+  default: true
+
 
 stages:
   - stage: 'documentation'
@@ -30,14 +34,15 @@ stages:
               mkdir -p "$(packages_dir)"
               mkdir -p "$(docs_build_dir)"
             displayName: 'Make directories'
-          - task: DownloadBuildArtifacts@0
-            inputs:
-              buildType: 'current'
-              specificBuildWithTriggering: true
-              downloadType: 'single'
-              artifactName: '$(package_name)'
-              downloadPath: '$(packages_dir)'
-            displayName: 'Download previously built conda package'
+          - ${{ if eq(parameters.build_package, true) }}:
+            - task: DownloadBuildArtifacts@0
+              inputs:
+                buildType: 'current'
+                specificBuildWithTriggering: true
+                downloadType: 'single'
+                artifactName: '$(package_name)'
+                downloadPath: '$(packages_dir)'
+              displayName: 'Download previously built conda package'
           - bash: |
               echo "##vso[task.prependpath]$CONDA/bin"
             displayName: Add Conda to PATH
@@ -47,11 +52,12 @@ stages:
               sed 's/- python$/- python=${{ parameters.py_version }}/g' ${{ parameters.conda_env }} > tempenv.yml
               conda env create -f tempenv.yml -n tempenv
             displayName: 'Create Conda environment'
-          - bash: |
-              set -ex
-              source activate tempenv
-              conda install "$(packages_dir)/$(package_name)/"*.tar.bz2
-            displayName: 'Install previously built conda package'
+          - ${{ if eq(parameters.build_package, true) }}:
+            - bash: |
+                set -ex
+                source activate tempenv
+                conda install "$(packages_dir)/$(package_name)/"*.tar.bz2
+              displayName: 'Install previously built conda package'
           - bash: |
               set -ex
               cd docs

--- a/stages.yml
+++ b/stages.yml
@@ -91,6 +91,7 @@ stages:
         publish_docs: ${{ parameters.publish_docs }}
         conda_label: ${{ parameters.conda_label }}
         gh_pages_subdirectory: ${{ parameters.gh_pages_subdirectory }}
+        publish_package: ${{ parameters.build_package }}
         package_list:
           ${{ each os in parameters.config }}:
             ${{ each py in os.Value.py_versions }}:

--- a/stages.yml
+++ b/stages.yml
@@ -47,27 +47,33 @@ parameters:
 - name: noarch
   type: boolean
   default: false
+- name: build_package
+  type: boolean
+  default: true
 
 stages:
+
   - template: code_quality_checks.yml
     parameters:
       image: ${{ parameters.settings.linux.image }}
-  - stage: 'build_and_test'
-    displayName: 'Build and Test'
-    jobs:
-      - ${{ each os in parameters.config }}:
-        - ${{ each py in os.Value.py_versions }}:
-          - template: build.yml
-            parameters:
-              verbose: ${{ parameters.verbose }}
-              py_version: ${{ py }}
-              image: ${{ parameters.settings[os.Key].image }}
-              conda_package_root: ${{ parameters.settings[os.Key].conda_package_root }}
-              conda_env: ${{ os.Value.conda_env }}
-              conda_channels: ${{ parameters.conda_channels }}
-              noarch: ${{ parameters.noarch }}
-              ${{ each param in parameters.settings[os.Key].params }}:
-                ${{ param.Key }}: ${{ param.Value }}
+
+  - ${{ if eq(parameters.build_package, true) }}:
+    - stage: 'build_and_test'
+      displayName: 'Build and Test'
+      jobs:
+        - ${{ each os in parameters.config }}:
+          - ${{ each py in os.Value.py_versions }}:
+            - template: build.yml
+              parameters:
+                verbose: ${{ parameters.verbose }}
+                py_version: ${{ py }}
+                image: ${{ parameters.settings[os.Key].image }}
+                conda_package_root: ${{ parameters.settings[os.Key].conda_package_root }}
+                conda_env: ${{ os.Value.conda_env }}
+                conda_channels: ${{ parameters.conda_channels }}
+                noarch: ${{ parameters.noarch }}
+                ${{ each param in parameters.settings[os.Key].params }}:
+                  ${{ param.Key }}: ${{ param.Value }}
 
   - template: documentation.yml
     parameters:
@@ -75,6 +81,7 @@ stages:
       conda_package_root: ${{ parameters.settings.linux.conda_package_root }}
       conda_env: ${{ parameters.config.linux.conda_env }}
       py_version: '3.7'
+      build_package: ${{ parameters.build_package }}
 
   - ${{ if eq(parameters.deploy, true) }}:
     - template: deploy.yml


### PR DESCRIPTION
This allows one to run a docs-only pipeline by skipping the build conda package stage.
This is required for the `ess-notebooks` repo.

**Note** that I am using a new flag for the `build_docs.py` (`--no-setup`) which skips the docs build setup (downloading data files, ...) when sphinx is run the second time to build the docs using `doctest`.

Once this is merged, all pipelines will fail on the other repositories until the `--no-setup` option is added to the `build_docs.py` file.