### PR TITLE
Generate env from meta

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -26,6 +26,9 @@ parameters:
 - name: noarch
   type: boolean
   default: false
+- name: conda_channels
+  type: string
+  default: ''
 
 jobs:
   - job:
@@ -58,7 +61,7 @@ jobs:
       - bash: |
           echo "##vso[task.setvariable variable=conda_dir]$CONDA"
         displayName: 'Configure Conda dir'
-     
+
       - ${{ if contains(parameters.conda_package_root, 'osx') }}:
         - bash: |
             set -ex
@@ -73,8 +76,10 @@ jobs:
 
       - bash: |
           set -ex
+          # Generate env file from conda recipe
+          python tools/metatoenv.py --dir=conda --env-file=buildenv.yml --channels=${{ parameters.conda_channels }}
           # Specify python version in env file
-          sed 's/- python$/- python=${{ parameters.py_version }}/g' ${{ parameters.conda_env }} > tempenv.yml
+          sed 's/- python$/- python=${{ parameters.py_version }}/g' buildenv.yml > tempenv.yml
           conda env create -f tempenv.yml -n tempenv
         displayName: 'Create conda environment'
         condition: eq(variables['buildcppfileexists'], 'true')

--- a/package-build.yml
+++ b/package-build.yml
@@ -88,7 +88,7 @@ jobs:
           set -ex
           export DOCS_BUILD_DIR=${{ variables.docs_build_dir }}
           conda build $VERBOSE_OPTION \
-            --channel conda-forge ${{ parameters.conda_channels }} \
+            --channel $(sed 's/,/ --channel /g' <<< ${{ parameters.conda_channels }}) \
             $SET_PYTHON_VERSION \
             --no-anaconda-upload \
             --override-channels \

--- a/stages.yml
+++ b/stages.yml
@@ -69,6 +69,7 @@ stages:
                 image: ${{ parameters.settings[os.Key].image }}
                 conda_package_root: ${{ parameters.settings[os.Key].conda_package_root }}
                 conda_env: ${{ os.Value.conda_env }}
+                conda_channels: ${{ parameters.conda_channels }}
                 noarch: ${{ parameters.noarch }}
                 ${{ each param in parameters.settings[os.Key].params }}:
                   ${{ param.Key }}: ${{ param.Value }}

--- a/test/.azure-pipelines/pull_request.yml
+++ b/test/.azure-pipelines/pull_request.yml
@@ -19,6 +19,7 @@ extends:
   template: ../../stages.yml
   parameters:
     verbose: ${{ parameters.verbose }}
+    conda_channels: 'conda-forge'
     config:
       linux:
         py_versions: ['3.7']

--- a/tools/metatoenv.py
+++ b/tools/metatoenv.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+import os
+import yaml
+import argparse
+
+parser = argparse.ArgumentParser(
+    description='Generate a conda environment file from a conda recipe meta.yaml file')
+parser.add_argument('--dir', default='.')
+parser.add_argument('--meta-file', default='meta.yaml')
+parser.add_argument('--config-file', default='conda_build_config.yaml')
+parser.add_argument('--env-file', default='environment.yml')
+parser.add_argument('--env-name', '--name', default='')
+parser.add_argument('--channels', default='conda-forge')
+parser.add_argument('--platform', '--os', default='linux64')
+
+
+def main(metafile, configfile, envfile, envname, channels, platform):
+
+    if os.path.exists(configfile):
+        with open(configfile, "r") as f:
+            config = yaml.safe_load(f)
+    else:
+        config = {}
+
+    with open(metafile, "r") as f:
+        asstring = f.read()
+
+    for key, value in config.items():
+        asstring = asstring.replace("{{{{ {} }}}}".format(key), "= {}".format(value[0]))
+    asstring = asstring.replace("{{", "")
+    asstring = asstring.replace("}}", "")
+    content = yaml.safe_load(asstring)
+
+    # Create dependencies
+    all_dependencies = []
+    for r in content["requirements"].values():
+        all_dependencies += r
+    all_dependencies += content["test"]["requires"]
+
+    # Filter out deps for selected OS
+    dependencies = []
+    for dep in all_dependencies:
+        ok = True
+        if dep.endswith(']'):
+            left = dep.rfind('[')
+            if left == -1:
+                raise RuntimeError("Unmatched square bracket in preprocessing selector")
+            selector = dep[left:]
+            if selector.startswith('[not'):
+                if (platform in selector) or (selector.replace('[not', '')[:-1].strip()
+                                              in platform):
+                    ok = False
+            else:
+                if (platform not in selector) and (selector[1:-1] not in platform):
+                    ok = False
+            if ok:
+                dep = dep.replace(selector, '').strip()
+        if ok and (dep not in dependencies):
+            dependencies.append(dep)
+
+    if len(envname) == 0:
+        envname = os.path.splitext(envfile)[0]
+    output = {"name": envname, "channels": channels, "dependencies": dependencies}
+
+    with open(envfile, "w") as out:
+        yaml.dump(output, out, default_flow_style=False)
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+
+    channels = [args.channels]
+    for delimiter in ":,":
+        if delimiter in args.channels:
+            channels = args.channels.split(delimiter)
+
+    main(metafile=os.path.join(args.dir, args.meta_file),
+         configfile=os.path.join(args.dir, args.config_file),
+         envfile=args.env_file,
+         envname=args.env_name,
+         channels=channels,
+         platform=args.platform)


### PR DESCRIPTION
Use the `metatoenv.py` script to parse the `conda/meta.yaml` (and corresponding `conda_build_config.yaml` file) to generate a conda env file, instead of relying on env files in the repo.